### PR TITLE
Add "server_name" config argument 

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -12,6 +12,7 @@ pub struct LuminaServer {
     pub bind_addr: SocketAddr,
     pub use_tls: Option<bool>,
     pub tls: Option<TlsIdentity>,
+    pub server_name: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/config-example.toml
+++ b/config-example.toml
@@ -3,6 +3,8 @@
 bind_addr = "0.0.0.0:1234"
 # indicates if TLS should be used for connections, if true the `lumina.tls` section is required.
 use_tls = false
+# server display name; appears in IDA output window
+server_name = "lumen.example.com"
 
 # only required when `use_tls` is set to true.
 [lumina.tls]


### PR DESCRIPTION
This allows choosing a server name to be displayed in the output window of IDA.
Before this change, hardcoded server domain appeared whenever lumen encountered an error.