### PR TITLE
Added docker-compose setup for easy configuration.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.env
+LICENSE
+README.md
+custom
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 Cargo.lock
 private/
+.env
 *.pem
 *.p12
 *.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM	debian:buster-slim
+ARG	DEBIAN_FRONTEND=noninteractive
+ENV 	RUSTUP_HOME=/usr/local/rustup \
+	CARGO_HOME=/usr/local/cargo \
+	PATH=/usr/local/cargo/bin:$PATH
+RUN	apt-get update && apt-get install -y --no-install-recommends --no-install-suggests ca-certificates pkg-config libssl-dev gcc-multilib curl && \
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s \
+	-- --default-toolchain nightly --profile minimal -y
+COPY	common	/lumen/common
+COPY	lumen	/lumen/lumen
+COPY	Cargo.toml /lumen/
+RUN	cd /lumen && cargo +nightly build --release
+
+FROM	debian:buster-slim
+ARG	DEBIAN_FRONTEND=noninteractive
+RUN	apt-get update && apt-get install -y --no-install-recommends --no-install-suggests openssl netcat-openbsd 
+COPY	--from=0	/lumen/target/release/lumen	/usr/bin/lumen
+COPY	config-example.toml	docker-init.sh	/lumen/
+WORKDIR	/lumen

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN	cd /lumen && cargo +nightly build --release
 
 FROM	debian:buster-slim
 ARG	DEBIAN_FRONTEND=noninteractive
-RUN	apt-get update && apt-get install -y --no-install-recommends --no-install-suggests openssl netcat-openbsd 
+RUN	apt-get update && apt-get install -y --no-install-recommends --no-install-suggests openssl netcat-openbsd && \
+	sed -i -e 's,\[ v3_req \],\[ v3_req \]\nextendedKeyUsage = serverAuth,' /etc/ssl/openssl.cnf 
 COPY	--from=0	/lumen/target/release/lumen	/usr/bin/lumen
 COPY	config-example.toml	docker-init.sh	/lumen/
+RUN	chmod ug+x /lumen/docker-init.sh && chmod ug+x /usr/bin/lumen
 WORKDIR	/lumen

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Pre-built binaries are not distributed at the moment, you will have to build _lu
 3. `cd lumen`
 4. Setup a Postgres database and execute src/schema.sql on it
 5. `cargo +nightly build --release`
+### Docker Method
+1. Install `docker-engine` and `docker-compose`.
+2. If using a custom TLS certificate, copy the private key (`.p12`/`.pfx` extension) to `./dockershare` and set the key password in `.env` as `PKCSPASSWD`.
+3. If using a custom Lumen config, copy it to `./dockershare/config.toml`.
+4. Otherwise, or if you have finished these steps, just run `docker-compose up`.
+5. Regardless, if TLS is enabled in the `config.toml`, a `hexrays.crt` will be generated in `./dockershare` to be copied to the IDA install directory.
 
 ### Usage
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.7'
+
+volumes:
+        postgres_data:
+services:
+        db:
+                image: postgres:13-alpine
+                container_name: lumina-postgres
+                environment:
+                        POSTGRES_USER: lumina
+                        POSTGRES_DB: lumina
+                        POSTGRES_PASSWORD: 1
+                expose:
+                        - "5432"
+                volumes:
+                        - postgres_data:/var/lib/postgresql
+                        - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
+        lumina:
+                build: .
+                command: sh -c 'while ! nc -vv -z db 5432; do sleep 1; done; /lumen/docker-init.sh'
+                depends_on:
+                        - db
+                ports:
+                        - 1234:1234
+                        - 8082:8082
+                environment:
+                        PKCSPASSWD: $PKCSPASSWD
+                volumes:
+                        - ./dockershare:/dockershare
+                links:
+                        - db

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+CFGPATH="/dockershare"
+KEYPATH="/lumen/lumen.p12"
+die(){
+    echo "Exiting due to error: $@" && exit 1
+}
+do_config_fixup(){
+           sed -i -e "s,connection_info.*,connection_info = \"host=db port=5432 user=lumina password=1\"," \
+	   /lumen/config.toml
+}
+use_default_config(){
+    echo "No custom config.toml found, creating secure default."
+    tee /lumen/config.toml <<- EOF > /dev/null
+	[lumina]
+	bind_addr = "0.0.0.0:1234"
+	use_tls = true
+	server_name = "lumen"
+	[lumina.tls]
+	server_cert = "${KEYPATH}"
+	[database]
+	connection_info = "host=db port=5432 user=lumina password=1"
+	use_tls = false
+	[api_server]
+	bind_addr = "0.0.0.0:8082"
+	EOF
+}
+use_default_key(){
+    openssl req -x509 -newkey rsa:4096 -keyout /lumen/lumen_key.pem -out /lumen/lumen_crt.pem -days 365 -nodes \
+	    --subj "/C=US/ST=Texas/L=Austin/O=Lumina/OU=Naimd/CN=lumen" -passout "pass:" || die "Generating key"
+    openssl pkcs12 -export -out /lumen/lumen.p12 -inkey /lumen/lumen_key.pem -in /lumen/lumen_crt.pem  \
+	    -passin "pass:" -passout "pass:" || die "Exporting key"
+    openssl x509 -in /lumen/lumen_crt.pem -out $CFGPATH/hexrays.crt -passin "pass:" || die "Exporting hexrays.crt"
+    echo "hexrays.crt added to mounted volume.  Copy this to your IDA install dir." ;
+    sed -i -e "s,server_cert.*,server_cert = \"${KEYPATH}\"," /lumen/config.toml ;
+}
+setup_tls_key(){
+    PRIVKEY=$(find $CFGPATH -type f \( -name '*.p12' -o -name '*.pfx' \) | head -1)
+    PASSIN="-passin pass:$PKCSPASSWD"
+    if [ ! -z "${PRIVKEY}" ] ; then
+        KEYNAME=$(basename "${PRIVKEY}")
+	KEYPATH="/lumen/${KEYNAME}"
+        echo "Starting lumen with custom TLS certificate ${KEYNAME}" ;
+        cp "${PRIVKEY}" $KEYPATH ;
+        openssl pkcs12 -in $KEYPATH ${PASSIN} -clcerts -nokeys -out $CFGPATH/hexrays.crt || die "Exporting hexrays.crt from private key. If there's a password, add it in .env as PKCSPASSWD=...";
+        echo "hexrays.crt added to mounted volume.  Copy this to your IDA install dir." ;
+        sed -i -e "s,server_cert.*,server_cert = \"${KEYPATH}\"," /lumen/config.toml
+    else
+        echo "No custom TLS key with p12/pfx extension in the custom mount directory." ;
+	use_default_key ;
+    fi ;
+}
+setup_config(){
+    if [ -e $CFGPATH/config.toml ] ; then
+        echo "Detected custom config.toml"
+        cp $CFGPATH/config.toml /lumen/config.toml ;
+        if grep use_tls /lumen/config.toml | head -1 | grep -q false ; then
+            echo "Starting lumen without TLS.  Make sure to set LUMINA_TLS = NO in ida.cfg" ;
+        else
+	    setup_tls_key ;
+        fi ;
+    else
+	use_default_config ;
+	setup_tls_key ;
+    fi        
+}
+
+setup_config ;
+do_config_fixup ;
+lumen -c /lumen/config.toml || die "Launching lumen";

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -26,7 +26,7 @@ use_default_config(){
 }
 use_default_key(){
     openssl req -x509 -newkey rsa:4096 -keyout /lumen/lumen_key.pem -out /lumen/lumen_crt.pem -days 365 -nodes \
-	    --subj "/C=US/ST=Texas/L=Austin/O=Lumina/OU=Naimd/CN=lumen" -passout "pass:" || die "Generating key"
+	    --subj "/C=US/ST=Texas/L=Austin/O=Lumina/OU=Naimd/CN=lumen" -passout "pass:" -extensions v3_req || die "Generating key"
     openssl pkcs12 -export -out /lumen/lumen.p12 -inkey /lumen/lumen_key.pem -in /lumen/lumen_crt.pem  \
 	    -passin "pass:" -passout "pass:" || die "Exporting key"
     openssl x509 -in /lumen/lumen_crt.pem -out $CFGPATH/hexrays.crt -passin "pass:" || die "Exporting hexrays.crt"


### PR DESCRIPTION
I'm sure many teams will benefit from Lumen.  To help them get started using it easier, I've made a `docker-compose` build for it.  It runs `postgres` in one container linked to `lumen` in another container.  I've done what I can to ensure small container image sizes.  I've tested the setup in various configurations, such as:
- [x] Using a custom `config.toml`
  - [x] with TLS disabled
  - [x] with TLS enabled
    - [x] with a custom p12 key used (password must be passed in `.env` file as `PKCSPASSWD`.
    - [x] with no custom key used, script generates self-signed one for the user within the container and spits out hexrays.crt into `./dockershare`
  - [ ] with postgres TLS used (for my docker-compose, it spins up its own postgres which is only accessible to the `lumen` container, so I disable TLS on the DB
- [x] Using no customizations (a default config is generated with a self-signed TLS key, spits out `hexrays.crt` to `./dockershare`)

Let me know if you have any questions.  Thanks for making Lumen!