### PR TITLE
Move to Rust stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install latest Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: stable
         override: true
         components: clippy
     - run: rustup component add clippy
@@ -32,7 +32,7 @@ jobs:
     - name: Install latest Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: stable
         override: true
         profile: minimal
     - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV 	RUSTUP_HOME=/usr/local/rustup \
 	PATH=/usr/local/cargo/bin:$PATH
 RUN	apt-get update && apt-get install -y --no-install-recommends --no-install-suggests ca-certificates pkg-config libssl-dev gcc-multilib curl && \
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s \
-	-- --default-toolchain nightly --profile minimal -y
+	-- --profile minimal -y
 COPY	common	/lumen/common
 COPY	lumen	/lumen/lumen
 COPY	Cargo.toml /lumen/
-RUN	cd /lumen && cargo +nightly build --release
+RUN	cd /lumen && cargo build --release
 
 FROM	debian:buster-slim
 ARG	DEBIAN_FRONTEND=noninteractive

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies)]
-#![feature(try_reserve)]
 
 use std::fmt::Write;
 

--- a/common/src/rpc/de.rs
+++ b/common/src/rpc/de.rs
@@ -14,7 +14,7 @@ impl<'de> Deserializer<'de> {
     }
     
     fn unpack_dd(&mut self) -> Result<u32, Error> {
-        let (v, len) = super::packing::unpack_dd(&self.input);
+        let (v, len) = super::packing::unpack_dd(self.input);
         if len == 0 {
             Err(Error::UnexpectedEof)
         } else {

--- a/lumen/src/main.rs
+++ b/lumen/src/main.rs
@@ -31,7 +31,7 @@ async fn handle_client<S: AsyncRead + AsyncWrite + Unpin>(state: &SharedState, m
     let config = state.config.as_ref();
     let hello = rpc::read_packet(&mut stream).await?;
 
-    let server_name = config.lumina.server_name.as_ref().map_or("lumen", |s| &s);
+    let server_name = config.lumina.server_name.as_ref().map_or("lumen", |s| s);
 
     let hello = match RpcMessage::deserialize(&hello) {
         Ok(RpcMessage::Hello(v)) => v,
@@ -87,7 +87,7 @@ async fn handle_client<S: AsyncRead + AsyncWrite + Unpin>(state: &SharedState, m
                 let statuses: Vec<u32> = funcs.iter().map(|v| if v.is_none() { 1 } else {0}).collect();
                 let found = funcs
                     .into_iter()
-                    .filter_map(|v| v)
+                    .flatten()
                     .map(|v| {
                         rpc::PullMetadataResultFunc {
                             popularity: v.popularity,
@@ -134,7 +134,7 @@ async fn handle_client<S: AsyncRead + AsyncWrite + Unpin>(state: &SharedState, m
 }
 
 async fn handle_connection<S: AsyncRead + AsyncWrite + Unpin>(state: &SharedState, s: S) {
-    if let Err(err) = handle_client(&state, s).await {
+    if let Err(err) = handle_client(state, s).await {
         warn!("err: {}", err);
     }
 }


### PR DESCRIPTION
With the release of Rust 1.57, _Lumen_ can be build using Rust's stable build.
(Previously not possible due to `try_reserve` being an unstable feature.)

This PR changes the default toolchain to `stable`.