### PR TITLE
Async drops

### DIFF
--- a/common/src/async_drop.rs
+++ b/common/src/async_drop.rs
@@ -1,0 +1,65 @@
+use futures_util::{future::BoxFuture, Future};
+use tokio::{sync::mpsc::{UnboundedSender, unbounded_channel, WeakUnboundedSender}};
+
+enum AsyncDropperMsg {
+    Future(BoxFuture<'static, ()>),
+    Termination,
+}
+
+pub struct AsyncDropper {
+    tx: UnboundedSender<AsyncDropperMsg>,
+}
+impl AsyncDropper {
+    pub fn new() -> (AsyncDropper, impl Future<Output = ()> + 'static) {
+        let (tx, mut rx) = unbounded_channel();
+        let fut = async move {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    AsyncDropperMsg::Future(fut) => {
+                        fut.await;
+                    },
+                    AsyncDropperMsg::Termination => {
+                        break;
+                    }
+                }
+            }
+            log::info!("term received...");
+        };
+
+        (Self { tx }, fut)
+    }
+
+    pub fn defer<F: Future<Output = ()> + Send + 'static>(&self, fut: F) -> AsyncDropGuard {
+        let tx = self.tx.downgrade();
+        AsyncDropGuard {
+            tx,
+            run: Some(Box::pin(fut))
+        }
+    }
+}
+impl Drop for AsyncDropper {
+    fn drop(&mut self) {
+        let _ = self.tx.send(AsyncDropperMsg::Termination);
+    }
+}
+
+pub struct AsyncDropGuard {
+    tx: WeakUnboundedSender<AsyncDropperMsg>,
+    run: Option<BoxFuture<'static, ()>>,
+}
+
+impl AsyncDropGuard {
+    pub fn consume(mut self) {
+        self.run.take();
+    }
+}
+
+impl Drop for AsyncDropGuard {
+    fn drop(&mut self) {
+        if let Some(fun) = self.run.take() {
+            if let Some(tx) = self.tx.upgrade() {
+                let _ = tx.send(AsyncDropperMsg::Future(fun));
+            }
+        }
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod md;
 pub mod rpc;
 pub mod web;
+pub mod async_drop;
 
 pub struct SharedState_ {
     pub db: db::Database,

--- a/lumen/src/main.rs
+++ b/lumen/src/main.rs
@@ -87,7 +87,7 @@ async fn handle_transaction<'a, S: AsyncRead + AsyncWrite + Unpin>(state: &Share
                     return Err(Error::Timeout);
                 }
             };
-            debug!("pull {}/{} funcs ended after {:?}", funcs.len(), md.funcs.len(), start.elapsed());
+            debug!("pull {}/{} funcs ended after {:?}", funcs.iter().filter(|v| v.is_some()).count(), md.funcs.len(), start.elapsed());
 
             let statuses: Vec<u32> = funcs.iter().map(|v| u32::from(v.is_none())).collect();
             let found = funcs

--- a/lumen/src/main.rs
+++ b/lumen/src/main.rs
@@ -66,7 +66,7 @@ async fn handle_transaction<'a, S: AsyncRead + AsyncWrite + Unpin>(state: &Share
     match req {
         RpcMessage::PullMetadata(md) => {
             let start = Instant::now();
-            let funcs = match timeout(Duration::from_secs(60 * 60),  db.get_funcs(&md.funcs)).await {
+            let funcs = match timeout(Duration::from_secs(4 * 60),  db.get_funcs(&md.funcs)).await {
                 Ok(r) => match r {
                     Ok(v) => v,
                     Err(e) => {


### PR DESCRIPTION
Ensures that some queries are terminated if the client leaves. This will require `tokio` to cancel futures to work (doesn't happen with TCP yet).