### PR TITLE
support delete command

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -13,6 +13,7 @@ pub struct LuminaServer {
     pub use_tls: Option<bool>,
     pub tls: Option<TlsIdentity>,
     pub server_name: Option<String>,
+    pub allow_deletes: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -325,4 +325,19 @@ impl Database {
             .collect();
         Ok(res)
     }
+
+    pub async fn delete_metadata(&self, req: &crate::rpc::DelHistory<'_>) -> Result<(), deadpool_postgres::PoolError> {
+        let conn = self.pool.get().await?;
+        let stmt = conn.prepare_cached("DELETE FROM funcs WHERE chksum = ANY($1)").await?;
+
+        let chksums = req.funcs.iter()
+            .map(|v| v.as_slice())
+            .collect::<Vec<_>>();
+        
+        conn.execute(&stmt, &[
+            &chksums
+        ]).await?;
+
+        Ok(())
+    }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -22,7 +22,7 @@ pub fn make_pretty_hex(data: &[u8]) -> String {
     const CHUNK_SIZE: usize = 32;
     data.chunks(CHUNK_SIZE).for_each(|chunk| {
         for &ch in chunk {
-            let _ = write!(&mut output, "{:02x} ", ch);
+            let _ = write!(&mut output, "{ch:02x} ");
         }
         let padding = CHUNK_SIZE - chunk.len();
         for _ in 0..padding {

--- a/common/src/rpc/messages.rs
+++ b/common/src/rpc/messages.rs
@@ -84,3 +84,24 @@ pub struct PushMetadataResult<'a> {
     // array of 0=exists, 1=NEW
     pub status: Cow<'a, [u32]>,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DelHistory<'a> {
+    pub unk0: u32, // =0x08
+    pub unk1: Cow<'a, [Cow<'a, str>]>,
+    pub unk2: Cow<'a, [[u64; 2]]>,
+    pub unk3: Cow<'a, [[u64; 2]]>,
+    pub unk4: Cow<'a, [Cow<'a, str>]>,
+    pub unk5: Cow<'a, [Cow<'a, str>]>,
+    pub unk6: Cow<'a, [Cow<'a, str>]>,
+    pub unk7: Cow<'a, [Cow<'a, str>]>,
+    pub unk8: Cow<'a, [Cow<'a, [u8; 16]>]>,
+    pub funcs: Cow<'a, [Cow<'a, [u8; 16]>]>,
+    pub unk10: Cow<'a, [[u64; 2]]>,
+    pub unk11: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct DelHistoryResult {
+    pub deleted_mds: u32,
+}

--- a/common/src/rpc/mod.rs
+++ b/common/src/rpc/mod.rs
@@ -116,6 +116,8 @@ pub enum RpcMessage<'a> {
     PullMetadataResult(PullMetadataResult<'a>),
     PushMetadata(PushMetadata<'a>),
     PushMetadataResult(PushMetadataResult<'a>),
+    DelHistory(DelHistory<'a>),
+    DelHistoryResult(DelHistoryResult),
 }
 
 impl<'a> serde::Serialize for RpcMessage<'a> {
@@ -137,6 +139,8 @@ impl<'a> serde::Serialize for RpcMessage<'a> {
             RpcMessage::PullMetadataResult(msg) => tuple.serialize_element(msg)?,
             RpcMessage::PushMetadata(msg) => tuple.serialize_element(msg)?,
             RpcMessage::PushMetadataResult(msg) => tuple.serialize_element(msg)?,
+            RpcMessage::DelHistory(msg) => tuple.serialize_element(msg)?,
+            RpcMessage::DelHistoryResult(msg) => tuple.serialize_element(msg)?,
         }
 
         tuple.end()
@@ -187,6 +191,8 @@ impl<'a> RpcMessage<'a> {
             0x0f => RpcMessage::PullMetadataResult(Self::deserialize_check(payload)?),
             0x10 => RpcMessage::PushMetadata(Self::deserialize_check(payload)?),
             0x11 => RpcMessage::PushMetadataResult(Self::deserialize_check(payload)?),
+            0x18 => RpcMessage::DelHistory(Self::deserialize_check(payload)?),
+            0x19 => RpcMessage::DelHistoryResult(Self::deserialize_check(payload)?),
             _ => {
                 trace!("got invalid message type '{:02x}'", msg_type);
                 return Err(Error::InvalidData);
@@ -217,6 +223,8 @@ impl<'a> RpcMessage<'a> {
             PullMetadataResult(_) => 0x0f,
             PushMetadata(_) => 0x10,
             PushMetadataResult(_) => 0x11,
+            DelHistory(_) => 0x18,
+            DelHistoryResult(_) => 0x19,
         }
     }
 }

--- a/common/src/web/api.rs
+++ b/common/src/web/api.rs
@@ -219,7 +219,7 @@ async fn view_status(state: SharedState) -> Result<impl Reply, Rejection> {
 
     let stats = match state.db.get_stats().await {
         Ok(stats) => DbStatus::Stats(stats),
-        Err(err) => DbStatus::Error(format!("{}", err)),
+        Err(err) => DbStatus::Error(format!("{err}")),
     };
 
     Result::<_, Rejection>::Ok(warp::reply::json(&Response {

--- a/config-example.toml
+++ b/config-example.toml
@@ -6,6 +6,9 @@ use_tls = false
 # server display name; appears in IDA output window
 server_name = "lumen"
 
+# Allow clients to delete metadata from the database?
+allow_deletes = false
+
 # only required when `use_tls` is set to true.
 [lumina.tls]
 # Specify the server's certificate. 

--- a/lumen/src/main.rs
+++ b/lumen/src/main.rs
@@ -178,7 +178,7 @@ async fn handle_client<S: AsyncRead + AsyncWrite + Unpin>(state: &SharedState, m
             // send error
             error!("got bad hello message");
 
-            let resp = rpc::RpcFail{ code: 0, message: &format!("{}: bad sequence.\n", server_name) };
+            let resp = rpc::RpcFail{ code: 0, message: &format!("{server_name}: bad sequence.") };
             let resp = rpc::RpcMessage::Fail(resp);
             resp.async_write(&mut stream).await?;
 

--- a/lumen/src/main.rs
+++ b/lumen/src/main.rs
@@ -131,6 +131,27 @@ async fn handle_transaction<'a, S: AsyncRead + AsyncWrite + Unpin>(state: &Share
                 status: Cow::Owned(status),
             }).async_write(&mut stream).await?;
         },
+        RpcMessage::DelHistory(req) => {
+            let is_delete_allowed = state.config.lumina.allow_deletes.unwrap_or(false);
+            if !is_delete_allowed {
+                RpcMessage::Fail(rpc::RpcFail {
+                    code: 2,
+                    message: &format!("{server_name}: Delete command is disabled on this server.")
+                }).async_write(&mut stream).await?;
+            } else {
+                if let Err(err) = db.delete_metadata(&req).await {
+                    error!("delete failed. db: {err}");
+                    RpcMessage::Fail(rpc::RpcFail {
+                        code: 3,
+                        message: &format!("{server_name}: db error, please try again later.")
+                    }).async_write(&mut stream).await?;
+                    return Ok(());
+                }
+                RpcMessage::DelHistoryResult(rpc::DelHistoryResult {
+                    deleted_mds: req.funcs.len() as u32,
+                }).async_write(&mut stream).await?;
+            }
+        },
         _ => {
             RpcMessage::Fail(rpc::RpcFail{code: 0, message: &format!("{server_name}: invalid data.\n")}).async_write(&mut stream).await?;
         }


### PR DESCRIPTION
This PR should close issue #56.
A new configuration option `lumen.allow_deletes` has been added, if set to true - any client connected to the server can request the deletion of functions. 